### PR TITLE
Fix parsing of access token.

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -61,7 +61,7 @@ class Provider extends AbstractProvider
     public function user()
     {
         $user = $this->mapUserToObject($this->getUserByToken(
-            $token = $this->getAccessToken($this->getCode())
+            $token = $this->parseAccessToken($this->getAccessTokenResponse($this->getCode()))
         ));
 
         return $user->setToken($token);


### PR DESCRIPTION
The provider was broken, as it was attempting to use a deprecated method to obtain the access token – `Laravel\Socialite\Two\AbstractProvider::getAccessToken()` – which was removed in [this commit](https://github.com/laravel/socialite/commit/0c234df124df24eed19355949d412ce66cee26fc#diff-8d3fd95aa368bbc8b78e7755afdf6132dbab48487f3f53591e55bf3f757f7121).

This PR updates the code to use the latest method(s).